### PR TITLE
Added serial-port context to config parameter

### DIFF
--- a/ESH-INF/thing/_controller_serial.xml
+++ b/ESH-INF/thing/_controller_serial.xml
@@ -38,6 +38,7 @@
             <parameter name="port" type="text" required="true"
                 groupName="port">
                 <label>Serial Port</label>
+                <context>serial-port</context>
                 <description>Set the serial port used to access the Z-Wave stick</description>
                 <default></default>
             </parameter>


### PR DESCRIPTION
With regard to https://community.openhab.org/t/jetty-update-karaf-4-1-3-upgrade-and-full-lsp-support/36354

Related to https://github.com/openhab/openhab2-addons/pull/2857 and https://github.com/openhab/openhab2-addons/pull/2852

Signed-off-by: Kuba Wolanin <hi@kubawolanin.com> (github: kubawolanin)